### PR TITLE
Peg sharedb to lever specific version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "arraydiff": "^0.1.1",
     "deep-is": "^0.1.3",
-    "sharedb": "^1.0.0-beta",
+    "sharedb": "^1.0.0-lever",
     "uuid": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The lever specific version of sharedb is more optimized for bulk
queries.

This will be published as `0.9.3-lever`